### PR TITLE
Fixed bug caused due to outdated versions

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-  - jupyterlab>=1.1.3
   - nodejs
   - bokeh
   - dask

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - zarr
   - pip
   - pip:
+    - jupyterlab
     - jupyter_bokeh
     - jupyterlab_widgets

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab>=1.1.3
+  - nodejs
   - bokeh
   - dask
   - matplotlib

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,3 +1,4 @@
+name: streaming-zarr
 channels:
   - conda-forge
 dependencies:
@@ -9,3 +10,7 @@ dependencies:
   - redis-py
   - xarray
   - zarr
+  - pip
+  - pip:
+    - jupyter_bokeh
+    - jupyterlab_widgets

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install @bokeh/jupyter_bokeh

--- a/example.ipynb
+++ b/example.ipynb
@@ -200,7 +200,7 @@
     "    source.patch({'img' : [(index, new_data)]})\n",
     "    p2d.title.text = f\"Streaming Conway's Game of Life - Timestep: {key}\"\n",
     "    p2d.title.align = \"left\"\n",
-    "    push_notebook(handle)\n",
+    "    push_notebook(handle=handle)\n",
     "\n",
     "cb = PeriodicCallback(update, 1000)\n",
     "cb.start()"

--- a/example.ipynb
+++ b/example.ipynb
@@ -169,7 +169,7 @@
     "img = data\n",
     "source = ColumnDataSource(data=dict(img=[img]))\n",
     "\n",
-    "p2d = figure(plot_width=500, plot_height=500, x_range=(0,shape[0]), y_range=(0,shape[1]),\n",
+    "p2d = figure(width=500, height=500, x_range=(0,shape[0]), y_range=(0,shape[1]),\n",
     "             title=f\"Streaming Conway's Game of Life - Timestep: {key}\")\n",
     "p2d.image(image='img', x=0, y=0, dw=shape[0], dh=shape[1], source=source)\n",
     "\n",


### PR DESCRIPTION
- JupyterLab extensions are now installed using pip as described [here](https://github.com/jupyter-widgets/ipywidgets/issues/2806) and [here](https://www.npmjs.com/package/@jupyter-widgets/jupyterlab-manager)
- Removed postBuild as it is not needed after the changes made above
- Added nodejs dependency in environment.yml as I was getting a missing dependency error when launching binder